### PR TITLE
Enhance dialog editor visuals

### DIFF
--- a/Assets/com.dialogs/Editor/DialogEditorWindow.cs
+++ b/Assets/com.dialogs/Editor/DialogEditorWindow.cs
@@ -29,6 +29,7 @@ public class DialogEditorWindow : EditorWindow
     private void SetupWindow()
     {
         rootVisualElement.Clear();
+        rootVisualElement.styleSheets.Add(Resources.Load<StyleSheet>("DialogStyle"));
         titleContent = new GUIContent(_dialogSo.name);
         var graph = new DialogGraph();
         graph.StretchToParentSize();
@@ -46,9 +47,14 @@ public class DialogEditorWindow : EditorWindow
     private void CreateToolBar()
     {
         var toolbar = new Toolbar();
+        toolbar.AddToClassList("dialog-toolbar");
 
         foreach (GraphAction graphAction in Enum.GetValues(typeof(GraphAction)))
-            toolbar.Add(new Button(() => ToolBarActionHandler(graphAction)) {text = graphAction.ToString()});
+        {
+            var button = new Button(() => ToolBarActionHandler(graphAction)) { text = graphAction.ToString() };
+            button.AddToClassList("dialog-toolbar-button");
+            toolbar.Add(button);
+        }
 
         rootVisualElement.Add(toolbar);
     }

--- a/Assets/com.dialogs/Editor/DialogGraph.cs
+++ b/Assets/com.dialogs/Editor/DialogGraph.cs
@@ -61,6 +61,7 @@ public class DialogGraph : GraphView
         foreach (var node in _dialogNodes)
         {
             AddElement(node);
+            node.AnimateIn();
             node.RefreshExpandedState();
             node.RefreshPorts();
         }
@@ -81,6 +82,7 @@ public class DialogGraph : GraphView
         var node = CreateNode(nodeData);
         _dialogNodes.Add(node);
         AddElement(node);
+        node.AnimateIn();
     }
 
     private DialogNode CreateNode(DialogSO.DialogNodeData nodeData)

--- a/Assets/com.dialogs/Editor/Nodes/DialogNode.cs
+++ b/Assets/com.dialogs/Editor/Nodes/DialogNode.cs
@@ -1,4 +1,6 @@
 ﻿using UnityEditor.Experimental.GraphView;
+using UnityEngine;
+using UnityEngine.UIElements;
 
 public class DialogNode : Node
 {
@@ -6,5 +8,13 @@ public class DialogNode : Node
     public DialogNode(DialogSO.DialogNodeData nodeData)
     {
         DialogNodeData = nodeData;
+        styleSheets.Add(Resources.Load<StyleSheet>("Node"));
+        AddToClassList("dialog-node");
+    }
+
+    public void AnimateIn()
+    {
+        // Delay applying the "show" class so transition animations play
+        schedule.Execute(() => AddToClassList("show")).ExecuteLater(1);
     }
 }

--- a/Assets/com.dialogs/Editor/Resources/DialogStyle.uss
+++ b/Assets/com.dialogs/Editor/Resources/DialogStyle.uss
@@ -1,6 +1,23 @@
 GridBackground {
-    --grid-background-color: #282828;
-    --line-color: rgba(193, 196, 192, 0.1);
-    --thick-line-color: rgba(193, 196, 192, 0.1);
-    --spacing: 10;
+    --grid-background-color: #1e1e1e;
+    --line-color: rgba(255, 255, 255, 0.05);
+    --thick-line-color: rgba(255, 255, 255, 0.1);
+    --spacing: 12;
+}
+
+.dialog-toolbar {
+    background-color: #2a2a2a;
+}
+
+.dialog-toolbar-button {
+    color: #eee;
+    font-size: 13px;
+    unity-font-style: bold;
+    margin-right: 4px;
+    transition-property: background-color;
+    transition-duration: 150ms;
+}
+
+.dialog-toolbar-button:hover {
+    background-color: #444;
 }

--- a/Assets/com.dialogs/Editor/Resources/Node.uss
+++ b/Assets/com.dialogs/Editor/Resources/Node.uss
@@ -1,5 +1,34 @@
-DialogueNode #title {
-    background-color: rgba(29, 115, 57, 0.91);
+.dialog-node {
+    background-color: #353535;
+    border-radius: 4px;
+    border-color: #222;
+    border-width: 1px;
+    border-style: solid;
+    color: #eee;
+    transition-property: transform, opacity, background-color;
+    transition-duration: 200ms;
+    transform: scale(0.9);
+    opacity: 0;
+}
+
+.dialog-node.show {
+    transform: scale(1);
+    opacity: 1;
+}
+
+.dialog-node:hover {
+    background-color: #444;
+}
+
+.dialog-node #title {
+    background-color: #1b5e20;
+    color: #fff;
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
+}
+
+.dialog-node Button {
+    margin-top: 2px;
 }
 
 #ChoicePort {
@@ -7,6 +36,7 @@ DialogueNode #title {
     flex-shrink: 1;
     justify-content:flex-start;
 }
+
 #top {
     flex-shrink: 1;
 }


### PR DESCRIPTION
## Summary
- add node style loading in `DialogNode`
- redesign node appearance
- tweak graph background and toolbar styles
- update editor window to use the new styles
- add entrance animation to nodes and toolbar button hover effect

## Testing
- `dotnet build Dialogs.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849ccc02b708333b65d6eb211daa6a0